### PR TITLE
Soporte para 6 digitos en el tomo y reformateo automatico de codigo

### DIFF
--- a/cedula.js
+++ b/cedula.js
@@ -20,7 +20,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-
 /**
  * Validates a Panamenial id (Cédula)
  *
@@ -28,11 +27,14 @@ SOFTWARE.
  *
  */
 function validateCedula(cedula) {
-  Array.prototype.insert = function (index, item) {
+  Array.prototype.insert = function(index, item) {
     this.splice(index, 0, item);
   };
-  var re=/^P$|^(?:PE|E|N|[23456789]|[23456789](?:A|P)?|1[0123]?|1[0123]?(?:A|P)?)$|^(?:PE|E|N|[23456789]|[23456789](?:AV|PI)?|1[0123]?|1[0123]?(?:AV|PI)?)-?$|^(?:PE|E|N|[23456789](?:AV|PI)?|1[0123]?(?:AV|PI)?)-(?:\d{1,4})-?$|^(PE|E|N|[23456789](?:AV|PI)?|1[0123]?(?:AV|PI)?)-(\d{1,4})-(\d{1,5})$/i
-  var matched = cedula.match(re)
+
+  var re = /^P$|^(?:PE|E|N|[23456789]|[23456789](?:A|P)?|1[0123]?|1[0123]?(?:A|P)?)$|^(?:PE|E|N|[23456789]|[23456789](?:AV|PI)?|1[0123]?|1[0123]?(?:AV|PI)?)-?$|^(?:PE|E|N|[23456789](?:AV|PI)?|1[0123]?(?:AV|PI)?)-(?:\d{1,4})-?$|^(PE|E|N|[23456789](?:AV|PI)?|1[0123]?(?:AV|PI)?)-(\d{1,4})-(\d{1,6})$/i;
+
+  var matched = cedula.match(re);
+
   // matched contains:
   // 1) if the cedula is complete (cedula = 8-AV-123-123)
   //    matched = [cedula, first part, second part, third part]
@@ -40,32 +42,41 @@ function validateCedula(cedula) {
   // 2) if the cedula is not complete (cedula = "1-1234")
   //    matched = ['1-1234', undefined, undefined, undefined]
   var isComplete = false;
+
   if (matched !== null) {
-    matched.splice(0,1); // remove the first match, it contains the input string.
-    if (matched[0] !== undefined) { // if matched[0] is set => cedula complete
+    matched.splice(0, 1); // remove the first match, it contains the input string.
+
+    if (matched[0] !== undefined) {
+      // if matched[0] is set => cedula complete
       isComplete = true;
+
       if (matched[0].match(/^PE|E|N$/)) {
-        matched.insert(0,'0');
+        matched.insert(0, "0");
       }
+
       if (matched[0].match(/^(1[0123]?|[23456789])?$/)) {
-        matched.insert(1,'');
+        matched.insert(1, "");
       }
+
       if (matched[0].match(/^(1[0123]?|[23456789])(AV|PI)$/)) {
         var tmp = matched[0].match(/(\d+)(\w+)/);
-        matched.splice(0,1);
-        matched.insert(0,tmp[1]);
-        matched.insert(1,tmp[2]);
+
+        matched.splice(0, 1);
+        matched.insert(0, tmp[1]);
+        matched.insert(1, tmp[2]);
       }
     } // matched[0]
   }
 
   var result = {
-      'isValid': cedula.length==0? true : re.test(cedula),
-      'inputString': cedula,
-      'isComplete': isComplete,
-      'cedula': isComplete ? matched.splice(0,4) : null
+    isValid: cedula.length === 0 ? true : re.test(cedula),
+    inputString: cedula,
+    isComplete: isComplete,
+    cedula: isComplete ? matched.splice(0, 4) : null
   };
-//  console.log(result);
+
+  //  console.log(result);
+
   return result;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,280 @@
+{
+  "name": "cedula-panama",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cedula-panama",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple validator of the Panamenian id (cedula)",
   "main": "cedula.js",
   "directories": {

--- a/test.js
+++ b/test.js
@@ -1,173 +1,202 @@
-var assert = require('assert');
-var cedula = require('./cedula');
+var assert = require("assert");
+var cedula = require("./cedula");
 
 //simulates typing the cedula
 //it should receive a valid cedula string to work
 function isValidCedulaFor(cedulaString) {
   //console.log(cedulaString.length);
-  for(var i=0;i<cedulaString.length;i++){
-    var c = cedula.validate(cedulaString.substring(0,i));
+  for (var i = 0; i < cedulaString.length; i++) {
+    var c = cedula.validate(cedulaString.substring(0, i));
     //console.log(c);
-    assert.equal(c.isValid,true,'testing: ' + cedulaString.substring(0,i));
+    assert.equal(c.isValid, true, "testing: " + cedulaString.substring(0, i));
   }
 }
+
 //simulates tiping cedula.
 //it should receive an inccomplete cedula to work
 function isNotCompleteCedulaFor(cedulaString) {
   //console.log(cedulaString.length);
-  for(var i=0;i<cedulaString.length;i++){
-    var c = cedula.validate(cedulaString.substring(0,i));
+  for (var i = 0; i < cedulaString.length; i++) {
+    var c = cedula.validate(cedulaString.substring(0, i));
     //console.log(c);
-    assert.equal(c.isComplete,false)
+    assert.equal(c.isComplete, false);
   }
 }
 
-describe('cedula.validate', function() {
-  it('should return isValid=true for an empty string', function() {
-    var c = cedula.validate('');
+describe("cedula.validate", function() {
+  it("should return isValid=true for an empty string", function() {
+    var c = cedula.validate("");
     assert.equal(c.isValid, true);
   });
 
-  it('should be a complete valid cedula 8-1234-12345', function() {
-    var c = cedula.validate('8-1234-12345');
+  it("should be a complete valid cedula 8-1234-12345", function() {
+    var c = cedula.validate("8-1234-12345");
     assert.equal(c.isValid, true);
-    assert.equal(c.inputString, '8-1234-12345')
+    assert.equal(c.inputString, "8-1234-12345");
     assert.equal(c.isComplete, true);
-    assert.equal(c.cedula[0], '8');
-    assert.equal(c.cedula[1], '');
-    assert.equal(c.cedula[2], '1234');
-    assert.equal(c.cedula[3], '12345');
+    assert.equal(c.cedula[0], "8");
+    assert.equal(c.cedula[1], "");
+    assert.equal(c.cedula[2], "1234");
+    assert.equal(c.cedula[3], "12345");
   });
 
-  it('should be a complete valid cedula PE-1234-12345', function() {
-    var c = cedula.validate('PE-1234-12345');
+  it("should be a complete valid cedula PE-1234-12345", function() {
+    var c = cedula.validate("PE-1234-12345");
     assert.equal(c.isValid, true);
-    assert.equal(c.inputString, 'PE-1234-12345')
+    assert.equal(c.inputString, "PE-1234-12345");
     assert.equal(c.isComplete, true);
-    assert.equal(c.cedula[0], '0');
-    assert.equal(c.cedula[1], 'PE');
-    assert.equal(c.cedula[2], '1234');
-    assert.equal(c.cedula[3], '12345');
+    assert.equal(c.cedula[0], "0");
+    assert.equal(c.cedula[1], "PE");
+    assert.equal(c.cedula[2], "1234");
+    assert.equal(c.cedula[3], "12345");
   });
 
-  it('should be a complete valid cedula N-1234-12345', function() {
-    var c = cedula.validate('N-1234-12345');
+  it("should be a complete valid cedula E-8-102017", function() {
+    var c = cedula.validate("E-8-102017");
     assert.equal(c.isValid, true);
-    assert.equal(c.inputString, 'N-1234-12345')
+    assert.equal(c.inputString, "E-8-102017");
     assert.equal(c.isComplete, true);
-    assert.equal(c.cedula[0], '0');
-    assert.equal(c.cedula[1], 'N');
-    assert.equal(c.cedula[2], '1234');
-    assert.equal(c.cedula[3], '12345');
+    assert.equal(c.cedula[0], "0");
+    assert.equal(c.cedula[1], "E");
+    assert.equal(c.cedula[2], "8");
+    assert.equal(c.cedula[3], "102017");
   });
 
-  it('should be a complete valid cedula E-1234-12345', function() {
-    var c = cedula.validate('E-1234-12345');
+  it("should be a complete valid cedula N-1234-12345", function() {
+    var c = cedula.validate("N-1234-12345");
     assert.equal(c.isValid, true);
-    assert.equal(c.inputString, 'E-1234-12345')
+    assert.equal(c.inputString, "N-1234-12345");
     assert.equal(c.isComplete, true);
-    assert.equal(c.cedula[0], '0');
-    assert.equal(c.cedula[1], 'E');
-    assert.equal(c.cedula[2], '1234');
-    assert.equal(c.cedula[3], '12345');
+    assert.equal(c.cedula[0], "0");
+    assert.equal(c.cedula[1], "N");
+    assert.equal(c.cedula[2], "1234");
+    assert.equal(c.cedula[3], "12345");
   });
 
-  it('should be a complete valid cedula 1PI-1234-12345', function() {
-    var c = cedula.validate('1PI-1234-12345');
+  it("should be a complete valid cedula E-1234-12345", function() {
+    var c = cedula.validate("E-1234-12345");
     assert.equal(c.isValid, true);
-    assert.equal(c.inputString, '1PI-1234-12345')
+    assert.equal(c.inputString, "E-1234-12345");
     assert.equal(c.isComplete, true);
-    assert.equal(c.cedula[0], '1');
-    assert.equal(c.cedula[1], 'PI');
-    assert.equal(c.cedula[2], '1234');
-    assert.equal(c.cedula[3], '12345');
+    assert.equal(c.cedula[0], "0");
+    assert.equal(c.cedula[1], "E");
+    assert.equal(c.cedula[2], "1234");
+    assert.equal(c.cedula[3], "12345");
   });
 
-  it('should be a complete valid cedula 13AV-1234-12345', function() {
-    var c = cedula.validate('10AV-1234-12345');
+  it("should be a complete valid cedula 1PI-1234-12345", function() {
+    var c = cedula.validate("1PI-1234-12345");
     assert.equal(c.isValid, true);
-    assert.equal(c.inputString, '10AV-1234-12345')
+    assert.equal(c.inputString, "1PI-1234-12345");
     assert.equal(c.isComplete, true);
-    assert.equal(c.cedula[0], '10');
-    assert.equal(c.cedula[1], 'AV');
-    assert.equal(c.cedula[2], '1234');
-    assert.equal(c.cedula[3], '12345');
+    assert.equal(c.cedula[0], "1");
+    assert.equal(c.cedula[1], "PI");
+    assert.equal(c.cedula[2], "1234");
+    assert.equal(c.cedula[3], "12345");
   });
 
-  it('should be NOT valid the cedula 111', function() {
-    var c = cedula.validate('111');
-    assert.equal(c.isValid, false);
-  });
-  it('should be NOT be valid the cedula A', function() {
-    var c = cedula.validate('A');
-    assert.equal(c.isValid, false);
-  });
-  it('should be NOT be valid the cedula P-', function() {
-    var c = cedula.validate('P-');
-    assert.equal(c.isValid, false);
-  });
-  it('should be NOT be valid the cedula 14-', function() {
-    var c = cedula.validate('14-');
-    assert.equal(c.isValid, false);
+  it("should be a complete valid cedula 13AV-1234-12345", function() {
+    var c = cedula.validate("10AV-1234-12345");
+    assert.equal(c.isValid, true);
+    assert.equal(c.inputString, "10AV-1234-12345");
+    assert.equal(c.isComplete, true);
+    assert.equal(c.cedula[0], "10");
+    assert.equal(c.cedula[1], "AV");
+    assert.equal(c.cedula[2], "1234");
+    assert.equal(c.cedula[3], "12345");
   });
 
-  it('should be NOT be valid the cedula 13-12345', function() {
-    var c = cedula.validate('13-12345');
+  it("should be NOT valid the cedula 111", function() {
+    var c = cedula.validate("111");
     assert.equal(c.isValid, false);
   });
 
-  it('should be NOT be valid the cedula 12-1234-1234567', function() {
-    var c = cedula.validate('12-1234-1234567');
+  it("should be NOT be valid the cedula A", function() {
+    var c = cedula.validate("A");
     assert.equal(c.isValid, false);
   });
 
+  it("should be NOT be valid the cedula P-", function() {
+    var c = cedula.validate("P-");
+    assert.equal(c.isValid, false);
+  });
 
-  it('should be isValid=true while tiping the cedula 1-12-123', function() {
-    isValidCedulaFor('1-12-123');
+  it("should be NOT be valid the cedula 14-", function() {
+    var c = cedula.validate("14-");
+    assert.equal(c.isValid, false);
   });
-  it('should be isValid=true while tiping the cedula 8-12-123', function() {
-    isValidCedulaFor('8-12-123');
+
+  it("should be NOT be valid the cedula 13-12345", function() {
+    var c = cedula.validate("13-12345");
+    assert.equal(c.isValid, false);
   });
-  it('should be isValid=true while tiping the cedula 12-12-12345', function() {
-    isValidCedulaFor('12-12-12345');
+
+  it("should be NOT be valid the cedula 12-1234-1234567", function() {
+    var c = cedula.validate("12-1234-1234567");
+    assert.equal(c.isValid, false);
   });
-  it('should be isValid=true while tiping the cedula PE-12-12345', function() {
-    isValidCedulaFor('PE-12-12345');
+
+  it("should be isValid=true while tiping the cedula 1-12-123", function() {
+    isValidCedulaFor("1-12-123");
   });
-  it('should be isValid=true while tiping the cedula N-12-123', function() {
-    isValidCedulaFor('N-12-123');
+
+  it("should be isValid=true while tiping the cedula 8-12-123", function() {
+    isValidCedulaFor("8-12-123");
   });
-  it('should be isValid=true while tiping the cedula E-12-123', function() {
-    isValidCedulaFor('E-12-123');
+
+  it("should be isValid=true while tiping the cedula 12-12-12345", function() {
+    isValidCedulaFor("12-12-12345");
   });
-  it('should be isValid=true while tiping the cedula 1PI-12-123', function() {
-    isValidCedulaFor('1PI-12-123');
+
+  it("should be isValid=true while tiping the cedula PE-12-12345", function() {
+    isValidCedulaFor("PE-12-12345");
   });
-  it('should be isValid=true while tiping the cedula 13-AV-12-123', function() {
-    isValidCedulaFor('13AV-12-123');
+
+  it("should be isValid=true while tiping the cedula N-12-123", function() {
+    isValidCedulaFor("N-12-123");
   });
-  it('should be isComplete=false while tiping the cedula 1-1234-', function() {
-    isNotCompleteCedulaFor('1-12-');
+
+  it("should be isValid=true while tiping the cedula E-12-123", function() {
+    isValidCedulaFor("E-12-123");
   });
-  it('should be isComplete=false while tiping the cedula 8-12-', function() {
-    isNotCompleteCedulaFor('8-12-');
+
+  it("should be isValid=true while tiping the cedula 1PI-12-123", function() {
+    isValidCedulaFor("1PI-12-123");
   });
-  it('should be isComplete=false while tiping the cedula 12-1234-', function() {
-    isNotCompleteCedulaFor('12-12-');
+
+  it("should be isValid=true while tiping the cedula 13-AV-12-123", function() {
+    isValidCedulaFor("13AV-12-123");
   });
-  it('should be isComplete=false while tiping the cedula PE-12-', function() {
-    isNotCompleteCedulaFor('PE-12-');
+
+  it("should be isComplete=false while tiping the cedula 1-1234-", function() {
+    isNotCompleteCedulaFor("1-12-");
   });
-  it('should be isComplete=false while tiping the cedula N-12-', function() {
-    isNotCompleteCedulaFor('N-12-');
+
+  it("should be isComplete=false while tiping the cedula 8-12-", function() {
+    isNotCompleteCedulaFor("8-12-");
   });
-  it('should be isComplete=false while tiping the cedula E-1234-', function() {
-    isNotCompleteCedulaFor('E-1234-');
+
+  it("should be isComplete=false while tiping the cedula 12-1234-", function() {
+    isNotCompleteCedulaFor("12-12-");
   });
-  it('should be isComplete=false while tiping the cedula 1PI-1234-', function() {
-    isNotCompleteCedulaFor('1PI-1234-');
+
+  it("should be isComplete=false while tiping the cedula PE-12-", function() {
+    isNotCompleteCedulaFor("PE-12-");
   });
-  it('should be isComplete=false while tiping the cedula 13AV-12-', function() {
-    isNotCompleteCedulaFor('13AV-12-');
+
+  it("should be isComplete=false while tiping the cedula N-12-", function() {
+    isNotCompleteCedulaFor("N-12-");
+  });
+
+  it("should be isComplete=false while tiping the cedula E-1234-", function() {
+    isNotCompleteCedulaFor("E-1234-");
+  });
+
+  it("should be isComplete=false while tiping the cedula 1PI-1234-", function() {
+    isNotCompleteCedulaFor("1PI-1234-");
+  });
+
+  it("should be isComplete=false while tiping the cedula 13AV-12-", function() {
+    isNotCompleteCedulaFor("13AV-12-");
   });
 });


### PR DESCRIPTION
Hola @merlos , gracias por poner esto junto. Lo hemos estado utilizando en IFARHU, por ejemplo en el Concurso General de Becas, que brinda oportunidades de estudio a más de 40 mil nuevos becarios cada año.

Este año, hemos detectado que algunas cédulas (sobre todo E) poseen 6 dígitos en el "tomo". Un ejemplo sería la cédula "E-8-102017".

Los commits incluyen los siguientes cambios:

- Agregando soporte para 6 dígitos en el tomo
- Se hizo un poco de format en el código, automáticamente aplicado con [Prettier](https://prettier.io/)
- Se subió a la versión `1.0.1`
- Se crearon los tests correspondientes